### PR TITLE
Added color for .ace_invisible

### DIFF
--- a/rstheme/night-owlish.rstheme
+++ b/rstheme/night-owlish.rstheme
@@ -39,6 +39,9 @@
 .ace_marker-layer .ace_selected-word {
 	border: 1px solid rgba(95, 126, 151, 0.47);
 }  
+.ace_invisible {
+	color: rgba(135, 156, 173, 0.4);
+}  
 .ace_fold {
 	background-color: #82AAFF;
 	border-color: #d6deeb;


### PR DESCRIPTION
The .ace_invisible class refers to RStudio's whitespace characters. Just a suggestion of an appropriate "feel" in line with other RStudio themes. I'll add comparison screenshots in an issue.