### PR TITLE
updated color of numeric values to match @sdras night-owl-vscode-theme

### DIFF
--- a/rstheme/ital-night-owl.rstheme
+++ b/rstheme/ital-night-owl.rstheme
@@ -57,7 +57,7 @@
 	color: #F78C6C;
 }  
 .ace_constant.ace_numeric {
-	color: #82AAFF;
+	color: #F78C6C;
 }  
 .ace_constant.ace_character {
 	color: #d3423e;

--- a/rstheme/night-owlish.rstheme
+++ b/rstheme/night-owlish.rstheme
@@ -59,7 +59,7 @@
 	color: #F78C6C;
 }  
 .ace_constant.ace_numeric {
-	color: #82AAFF;
+	color: #F78C6C;
 }  
 .ace_constant.ace_character {
 	color: #d3423e;


### PR DESCRIPTION
This updates the theme so that numeric values show as a different color than functions (see image below)

![after](https://user-images.githubusercontent.com/7331561/72946433-efe82a00-3d4c-11ea-9c57-e2068d2ff5e0.PNG)

The colors of brackets and operators still do not match the [@sdras](https://github.com/sdras) [night-owl-vscode-theme](https://github.com/sdras/night-owl-vscode-theme) but I do not see a way around this because `.ace_keyword.ace_operator` overrides `.ace_keyword` according to [this documentation](https://rstudio.github.io/rstudio-extensions/rstudio-theme-creation.html).